### PR TITLE
[28722][FIX] maintenance_plan Backport bufgixes from V15 (28446):

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Maintenance Plan",
     "summary": "Extends preventive maintenance planning",
-    "version": "14.0.1.5",
+    "version": "14.0.1.6",
     "author": "Camptocamp SA, ForgeFlow, Odoo Community Association (OCA) (Forked by Logicasoft)",
     "license": "AGPL-3",
     "category": "Maintenance",

--- a/maintenance_plan/i18n/fr_BE.po
+++ b/maintenance_plan/i18n/fr_BE.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-14 09:56+0000\n"
-"PO-Revision-Date: 2022-01-14 09:56+0000\n"
+"POT-Creation-Date: 2024-01-10 07:35+0000\n"
+"PO-Revision-Date: 2024-01-10 07:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -208,7 +208,6 @@ msgid "Maintenance Plan"
 msgstr "Planification de maintenance"
 
 #. module: maintenance_plan
-#: model:ir.model.fields,field_description:maintenance_plan.field_lims_config_settings__maintenance_plan_base_date
 #: model:ir.model.fields,field_description:maintenance_plan.field_res_config_settings__maintenance_plan_base_date
 msgid "Maintenance Plan Base Date"
 msgstr "Date utilisée pour la planification de maintenance"
@@ -279,7 +278,8 @@ msgid ""
 "Maintenance planning horizon. Only the maintenance requests inside the "
 "horizon will be created."
 msgstr ""
-"Horizon de maintenance. Seules les demandes de maintenance à l'intérieur de cet horizon seront créées "
+"Horizon de maintenance. Seules les demandes de maintenance à l'intérieur de "
+"cet horizon seront créées "
 
 #. module: maintenance_plan
 #: model:ir.actions.act_window,name:maintenance_plan.maintenance_plan_action
@@ -290,11 +290,19 @@ msgstr "Planifications de maintenance"
 #. module: maintenance_plan
 #: model_terms:ir.ui.view,arch_db:maintenance_plan.res_config_settings_maintenance_form
 msgid ""
-"Maintenance request date used to determine the next maintenance date when a "
-"maintenance plan is configured"
+"Maintenance request date used to determine the next maintenance date when a maintenance plan is configured\n"
+"                                    <br/>\n"
+"                                    <em>\n"
+"                                        Note that 'Done date' configuration is not compatible with the configuration of planning horizons on\n"
+"                                        maintenance plans\n"
+"                                    </em>"
 msgstr ""
 "Date de la demande de maintenance qui sera utilisée pour déterminer la date de la prochaine maintenance "
 "sur les planifications de maintenance"
+"                                    <br/>\n"
+"                                    <em>\n"
+"La configuration 'Date de fin' n'est pas compatible avec la configuration des horizons dans les planifications de maintenance\n"
+"                                    </em>"
 
 #. module: maintenance_plan
 #: model:ir.model.fields,field_description:maintenance_plan.field_maintenance_plan__maintenance_ids
@@ -362,13 +370,11 @@ msgid "Recurrence"
 msgstr "Récurrence"
 
 #. module: maintenance_plan
-#: model:ir.model.fields.selection,name:maintenance_plan.selection__lims_config_settings__maintenance_plan_base_date__request_date
 #: model:ir.model.fields.selection,name:maintenance_plan.selection__res_config_settings__maintenance_plan_base_date__request_date
 msgid "Request Date"
 msgstr "Date demandée"
 
 #. module: maintenance_plan
-#: model:ir.model.fields.selection,name:maintenance_plan.selection__lims_config_settings__maintenance_plan_base_date__schedule_date
 #: model:ir.model.fields.selection,name:maintenance_plan.selection__res_config_settings__maintenance_plan_base_date__schedule_date
 msgid "Scheduled Date"
 msgstr "Date prévue"

--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -109,7 +109,9 @@ class MaintenanceEquipment(models.Model):
         requests = self.env["maintenance.request"]
         # Create maintenance request until we reach planning horizon
         while next_maintenance_date <= horizon_date:
-            if next_maintenance_date >= fields.Date.from_string(fields.Date.today()):
+            if next_maintenance_date >= fields.Date.today() and not self.maintenance_ids.filtered(
+                lambda m: m.maintenance_plan_id.id == maintenance_plan.id and m.request_date == next_maintenance_date
+                          and not m.stage_id.done):
                 vals = self._prepare_request_from_plan(
                     maintenance_plan, next_maintenance_date
                 )

--- a/maintenance_plan/models/maintenance_request.py
+++ b/maintenance_plan/models/maintenance_request.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
+from datetime import datetime
 
 
 class MaintenanceRequest(models.Model):
@@ -36,5 +37,10 @@ class MaintenanceRequest(models.Model):
         """
         self.ensure_one()
         base_date = self.env['ir.config_parameter'].sudo().get_param('maintenance.plan.base.date', 'done_date')
-        request_date = self.read([base_date])
-        return request_date[0].get(base_date) or fields.Date.today()
+        request_dict = self.read([base_date])
+        # If base date is not set yet (e.g. when creating requests from horizon planning), we must fall back to
+        # standard behavior and use request date as base date
+        request_date = request_dict[0].get(base_date) or self.request_date
+        if request_date and isinstance(request_date, datetime):
+            request_date = request_date.date()
+        return request_date

--- a/maintenance_plan/views/res_config_settings.xml
+++ b/maintenance_plan/views/res_config_settings.xml
@@ -28,6 +28,11 @@
                                 <label for="maintenance_plan_base_date" />
                                 <div class="text-muted">
                                     Maintenance request date used to determine the next maintenance date when a maintenance plan is configured
+                                    <br/>
+                                    <em>
+                                        Note that 'Done date' configuration is not compatible with the configuration of planning horizons on
+                                        maintenance plans
+                                    </em>
                                 </div>
                                 <div class="content-group">
                                     <div class="mt16">


### PR DESCRIPTION
Fix computation of next maintenance date (if base date is not set on last request, use request date) 
Fix bug when horizon is set and done date is used as base date